### PR TITLE
Avoid code replication

### DIFF
--- a/conversion.js
+++ b/conversion.js
@@ -1,5 +1,5 @@
 function parseConvertedValue(value) {
-  return parseFloat(value).toFixed(1);
+  return parseFloat(value).toFixed(1)
 }
 
 let toCelsius = (degrees) => {

--- a/conversion.js
+++ b/conversion.js
@@ -1,11 +1,15 @@
+function parseConvertedValue(value) {
+  return parseFloat(value).toFixed(1);
+}
+
 let toCelsius = (degrees) => {
   let celsius = (degrees - 32) * (5 / 9)
-  return parseFloat(celsius).toFixed(1)
+  return parseConvertedValue(celsius)
 }
 
 let toFahrenheit = (degrees) => {
   let fahrenheit = (degrees * (9 / 5)) + 32
-  return parseFloat(fahrenheit).toFixed(1)
+  return parseConvertedValue(fahrenheit)
 }
 
 module.exports = {


### PR DESCRIPTION
Created `parseConvertedValue(value)` method to avoid replication on both `toCelsius` and `toFahrenheit` methods.